### PR TITLE
Fix zero width match

### DIFF
--- a/ov.el
+++ b/ov.el
@@ -109,13 +109,17 @@ If BEG and END are numbers, they specify the bounds of the search."
 If BEG and END are numbers, they specify the bounds of the search."
   (save-excursion
     (goto-char (or beg (point-min)))
-    (let (ov-or-ovs)
+    (let (ov-or-ovs finish)
       (ov-recenter (point-max))
-      (while (re-search-forward regexp end t)
+      (while (and (not finish) (re-search-forward regexp end t))
         (setq ov-or-ovs (cons (ov-make (match-beginning 0)
                                        (match-end 0)
                                        nil (not ov-sticky-front) ov-sticky-rear)
-                              ov-or-ovs)))
+                              ov-or-ovs))
+        (when (= (match-beginning 0) (match-end 0))
+          (if (eobp)
+              (setq finish t)
+            (forward-char 1))))
       ov-or-ovs)))
 
 (defun ov-region ()

--- a/test/ov-test.el
+++ b/test/ov-test.el
@@ -75,6 +75,12 @@
   (should-error (ov-regexp 1))
   (should-error (ov-regexp)))
 
+;; https://github.com/ShingoFukuyama/ov.el/issues/8
+(ert-deftest ov-test/ov-regexp-zero-width-match ()
+  "Not infinite loop with zero width match such as `$'"
+  (ov-test-insert-dummy-text)
+  (should (listp (ov-regexp "$"))))
+
 (ert-deftest ov-test/ov-set ()
   (ov-test-insert-dummy-text)
   (setq ov1 (ov-set (ov-line) 'face 'warning))


### PR DESCRIPTION
're-search-forward' does not move point if regexp matches empty string
like '$', '^', '\=' etc. This may cause infinite loop. So point must
be forwarded when regexp matches empty string for avoiding infinite loop.

This is related to #8

CC: @mgalgs
